### PR TITLE
:sparkles: querydsl을 도입한기 위한 환경 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 apply from: "$rootDir/jacoco.gradle"
-apply from: "$rootDir/checkstyle.gradle"
+//apply from: "$rootDir/checkstyle.gradle"
 
 configurations {
     compileOnly {
@@ -42,6 +42,12 @@ dependencies {
     // postgresql
     implementation 'org.postgresql:postgresql:42.7.2'
 
+    // querydsl 관련 의존성
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // spring boot test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
@@ -56,6 +62,21 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
 
+}
+def querydslSrcDir = "$buildDir/generated/sources/annotationProcessor/java/main"
+clean {
+    delete file(querydslSrcDir)
+}
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory = file(querydslSrcDir)
+}
+// sourceSets에 QueryDSL로 생성된 Q 클래스 경로 추가
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src/main/java', querydslSrcDir]
+        }
+    }
 }
 test {
     useJUnitPlatform() // JUnit 5 플랫폼 사용

--- a/src/main/java/potato/onetake/global/config/QuerydslConfig.java
+++ b/src/main/java/potato/onetake/global/config/QuerydslConfig.java
@@ -1,0 +1,21 @@
+package potato.onetake.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+	private final EntityManager entityManager;
+
+	public QuerydslConfig(final EntityManager entityManager) {
+		this.entityManager = entityManager;
+	}
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}


### PR DESCRIPTION
## 연관된 작업사항
- interview 세션 진행 중 랜덤으로 질문 뽑아오기

## 작업내용
- build.gradle에 dsl 환경을 위해 의존성 주입
- 스프링에서 dsl을 공식 지원하지 않아, build를 위한 각종 설정
  - Qentity가 만들어지는 패스 설정
  - 컴파일 때 추가하도록 수정
- dsl 사용을 위한 Config 파일 작성
  - JPAQueryFactory는 작성한 커스텀 쿼리를 진짜 쿼리문으로 바꿔고 데이터베이스에서 실행해줌
  - Bean 등록을 통해 스프링 컨테이너로 관리
    - 여러 서비스나 리포지토리에서 사용될 수 있기 때문에, 매번 객체를 생성하지 않고 스프링 컨테이너에서 생성된 하나의 인스턴스를 재사용하는 것이 효율적
    - JPAQueryFactory는 EntityManager에 의존하는데, 스프링에서 EntityManager를 자동으로 관리하고 제공하기 때문에, JPAQueryFactory에 이를 주입하여 동작할 수 있게 만듬
    - PAQueryFactory를 스프링 빈으로 등록하면, 추후에 QueryDSL 설정이나 EntityManager 설정을 변경하더라도 해당 빈을 관리하는 곳에서만 수정하면 되므로, 전체 코드 수정 범위 줄어듬

## Reference
- https://batory.tistory.com/496
- https://velog.io/@martindog/Spring-JPAQueryFactory-%EC%9D%B4%EC%9A%A9%ED%95%98%EA%B8%B0
- https://starsufers.tistory.com/30
- https://velog.io/@gudcks0305/SpringQueryDsl-%EB%8F%84%EC%9E%85%EA%B8%B0

## etc.
