### PR TITLE
:sparkles: 카테고리 별로 랜덤 질문 뽑는 query 작성

### DIFF
--- a/src/main/java/potato/onetake/domain/Content/dao/QuestionCategoryRepository.java
+++ b/src/main/java/potato/onetake/domain/Content/dao/QuestionCategoryRepository.java
@@ -5,5 +5,6 @@ import org.springframework.stereotype.Repository;
 import potato.onetake.domain.Content.domain.QuestionCategory;
 
 @Repository
-public interface QuestionCategoryRepository extends JpaRepository<QuestionCategory, Long> {
+public interface QuestionCategoryRepository extends JpaRepository<QuestionCategory, Long>, QuestionCategoryRepositoryCustom {
+
 }

--- a/src/main/java/potato/onetake/domain/Content/dao/QuestionCategoryRepositoryCustom.java
+++ b/src/main/java/potato/onetake/domain/Content/dao/QuestionCategoryRepositoryCustom.java
@@ -1,0 +1,10 @@
+package potato.onetake.domain.Content.dao;
+
+import potato.onetake.domain.Content.domain.QuestionCategory;
+
+import java.util.List;
+import java.util.Map;
+
+public interface QuestionCategoryRepositoryCustom {
+	List<QuestionCategory> findRandByCategoryIdList(Map<Long, Integer> categoryIdAndNumList);
+}

--- a/src/main/java/potato/onetake/domain/Content/dao/QuestionCategoryRepositoryCustomImpl.java
+++ b/src/main/java/potato/onetake/domain/Content/dao/QuestionCategoryRepositoryCustomImpl.java
@@ -1,0 +1,38 @@
+package potato.onetake.domain.Content.dao;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import potato.onetake.domain.Content.domain.QuestionCategory;
+
+import java.util.List;
+import java.util.Map;
+
+public class QuestionCategoryRepositoryCustomImpl implements QuestionCategoryRepositoryCustom {
+
+	@PersistenceContext
+	private EntityManager em;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public List<QuestionCategory> findRandByCategoryIdList(Map<Long, Integer> categoryIdAndNumList) {
+		StringBuilder sb = new StringBuilder();
+
+		boolean first = true;
+		for (Map.Entry<Long, Integer> entry : categoryIdAndNumList.entrySet()) {
+			if (!first) {
+				sb.append(" UNION ALL ");
+			}
+			sb.append("(select * from question_category WHERE category_id =")
+				.append(entry.getKey())
+				.append(" ORDER BY RANDOM() LIMIT ")
+				.append(entry.getValue())
+				.append(")");
+			first = false;
+		}
+
+		Query query = em.createNativeQuery(sb.toString());
+
+		return (List<QuestionCategory>) query.getResultList();
+	}
+}

--- a/src/main/java/potato/onetake/domain/Ineterview/service/InterviewService.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/service/InterviewService.java
@@ -159,7 +159,7 @@ public class InterviewService {
 			reportDto.setTitle(interviewEntity.getTitle());
 			List<InterviewReportResponseDto.InterviewQnaReportDto> qnaReport = qnaList.stream().map(
 				interviewQna -> {
-					Question question = interviewQna.getQuestion();
+					Question question = interviewQna.getQuestionCategory().getQuestion();
 					String questionContent = question.getContent();
 					String answer = interviewQna.getAnswer(); // TODO: answer이 없을 경우, 예외 필요
 					// TODO: 레포트 생성하는 부분 처리 필요


### PR DESCRIPTION
## 연관된 작업사항

## 작업내용
- Long: pk, Integer: 카테고리 별 질문의 개수
- 카테고리 별로 주어진 질문에 개수에 맞게 뽑은뒤, 첫 쿼리가 아니라면 union으로 쿼리들을 결합
- 후에 한 번에 쿼리를 실행시켜 객체 리스트를 반환받는다

## Reference


## etc.
