### PR TITLE
:sparkles: Interview Custom Exception 구현

### DIFF
--- a/src/main/java/potato/onetake/domain/Ineterview/exception/InterviewErrorCode.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/exception/InterviewErrorCode.java
@@ -1,0 +1,19 @@
+package potato.onetake.domain.Ineterview.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import potato.onetake.global.exception.ErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum InterviewErrorCode implements ErrorCode {
+
+	INTERVIEW_NOT_FOUND(2000,"인터뷰 세션을 찾지 못했습니다."),
+	CATEGORY_NOT_FOUND(2001, "카테고리를 찾지 못했습니다."),
+	PROFILE_NOT_FOUND(2002, "프로필을 찾지 못했습니다."),
+	QUESTION_NOT_FOUND(2003, "질문을 찾지 못했습니다."),
+	INVALID_CATEGORY(2005, "질문 생성 중 카테고리에 문제가 발생했습니다.");
+
+	private final int errorCode;
+	private final String errorMessage;
+}

--- a/src/main/java/potato/onetake/domain/Ineterview/exception/InterviewErrorCode.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/exception/InterviewErrorCode.java
@@ -12,7 +12,8 @@ public enum InterviewErrorCode implements ErrorCode {
 	CATEGORY_NOT_FOUND(2001, "카테고리를 찾지 못했습니다."),
 	PROFILE_NOT_FOUND(2002, "프로필을 찾지 못했습니다."),
 	QUESTION_NOT_FOUND(2003, "질문을 찾지 못했습니다."),
-	INVALID_CATEGORY(2005, "질문 생성 중 카테고리에 문제가 발생했습니다.");
+	ANSWER_NOT_FOUND(2004, "질문에 대한 답을 찾지 못했습니다."),
+	INVALID_CATEGORY(2010, "질문 생성 중 카테고리에 문제가 발생했습니다.");
 
 	private final int errorCode;
 	private final String errorMessage;

--- a/src/main/java/potato/onetake/domain/Ineterview/exception/InterviewException.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/exception/InterviewException.java
@@ -34,4 +34,8 @@ public class InterviewException extends CustomException {
 		public QuestionNotFoundException() { super(InterviewErrorCode.QUESTION_NOT_FOUND); }
 	}
 
+	public static class AnswerNotFoundException extends InterviewException {
+		public AnswerNotFoundException() { super(InterviewErrorCode.ANSWER_NOT_FOUND); }
+	}
+
 }

--- a/src/main/java/potato/onetake/domain/Ineterview/exception/InterviewException.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/exception/InterviewException.java
@@ -1,0 +1,37 @@
+package potato.onetake.domain.Ineterview.exception;
+
+import potato.onetake.global.exception.CustomException;
+
+/**
+ * INTERVIEW_NOT_FOUND(2000,"인터뷰 세션을 찾지 못했습니다."),
+ * CATEGORY_NOT_FOUND(2001, "카테고리를 찾지 못했습니다."),
+ * INVALID_CATEGORY(2005, "질문 생성 중 카테고리에 문제가 발생했습니다.");
+ * PROFILE_NOT_FOUND(2002, "프로필을 찾지 못했습니다."),
+ * QUESTION_NOT_FOUND(2003, "질문을 찾지 못했습니다."),
+ */
+public class InterviewException extends CustomException {
+	public InterviewException(InterviewErrorCode interviewErrorCode) {
+		super(interviewErrorCode);
+	}
+
+	public static class InterviewNotFoundException extends InterviewException {
+		public InterviewNotFoundException() { super(InterviewErrorCode.INTERVIEW_NOT_FOUND); }
+	}
+
+	public static class CategoryNotFoundException extends InterviewException {
+		public CategoryNotFoundException() { super(InterviewErrorCode.CATEGORY_NOT_FOUND); }
+	}
+
+	public static class InvalidCategoryException extends InterviewException {
+		public InvalidCategoryException() { super(InterviewErrorCode.CATEGORY_NOT_FOUND); }
+	}
+
+	public static class ProfileNotFoundException extends InterviewException {
+		public ProfileNotFoundException() { super(InterviewErrorCode.PROFILE_NOT_FOUND); }
+	}
+
+	public static class QuestionNotFoundException extends InterviewException {
+		public QuestionNotFoundException() { super(InterviewErrorCode.QUESTION_NOT_FOUND); }
+	}
+
+}

--- a/src/main/java/potato/onetake/domain/Ineterview/service/InterviewService.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/service/InterviewService.java
@@ -1,6 +1,7 @@
 package potato.onetake.domain.Ineterview.service;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.BadRequestException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ import potato.onetake.domain.Ineterview.domain.Interview;
 import potato.onetake.domain.Ineterview.domain.InterviewCategory;
 import potato.onetake.domain.Ineterview.domain.InterviewQna;
 import potato.onetake.domain.Ineterview.dto.*;
+import potato.onetake.domain.Ineterview.exception.InterviewException;
 import potato.onetake.domain.Position.dao.ProfileRepository;
 import potato.onetake.domain.Position.domain.Profile;
 
@@ -36,45 +38,76 @@ public class InterviewService {
 	private final QuestionCategoryRepository questionCategoryRepository;
 
 	/**
+	 * createInterview 메서드
+	 * 인터뷰 세션을 생성하고, 사용자의 프로필과 선택된 카테고리 기반으로 인터뷰를 구성합니다.
 	 *
-	 * @param interviewBeginRequestDto
-	 * 시큐리티 컨텍스트에서 로그인 정보 가져온뒤 프로필 정보 가져옴
-	 * 만들어진 카테고리와 request로 받은 카테고리 정보를 기반으로 interview-category 다대다 관계 설정
-	 * 이후, 아직은 미구현이지만, 카테고리를 기반으로 qna 테이블
-	 * 인터뷰 <- 카테고리 기반으로 질문을 가져와야함
-	 * 1. 퀘스천 자체에 카테고리 추가
-	 * @return interview
+	 * @param interviewBeginRequestDto 사용자로부터 받은 인터뷰 시작 요청 정보
+	 *  - 사용자 프로필을 조회하고, 선택된 카테고리로 인터뷰를 생성
+	 *  - 각 카테고리에 대해 InterviewCategory 및 InterviewQna를 생성
+	 *
+	 * 처리 단계:
+	 * 1. 시큐리티 컨텍스트에서 로그인된 사용자 ID를 가져옵니다.
+	 * 2. 사용자 프로필을 조회하고, 프로필이 없으면 예외를 던집니다.
+	 * 3. 주어진 제목으로 인터뷰 세션을 생성하고 저장합니다.
+	 * 4. 사용자가 선택한 카테고리로 InterviewCategory를 생성하여 저장합니다.
+	 * 5. 각 카테고리에 속한 질문들로 InterviewQna를 생성하여 인터뷰와 연결합니다.
+	 *
+	 * @return InterviewBeginResponseDto - 생성된 인터뷰 세션 ID를 포함한 응답 DTO를 반환
 	 */
 	@Transactional
 	public InterviewBeginResponseDto createInterview(final InterviewBeginRequestDto interviewBeginRequestDto) {
 
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-		Long userId = Long.parseLong(authentication.getName()); // 추후 시큐리티 완성 후 맞게 수정 필요
+		long userId;
+		try {
+			userId = Long.parseLong(authentication.getName()); // 추후 시큐리티 완성 후 맞게 수정 필요
+		} catch (NumberFormatException e) {
+			throw new InterviewException.ProfileNotFoundException(); // userId를 찾지 못했을 때 예외 발생
+		}
 
-		final Profile profile = profileRepository.getReferenceById(userId);
+		final Profile profile = profileRepository.findById(userId)
+			.orElseThrow(InterviewException.ProfileNotFoundException::new);
 
 		Interview interview = new Interview(profile, interviewBeginRequestDto.getTitle());
-
 		interviewRepository.save(interview);
 
 		List<Long> categoryIdList = new ArrayList<Long>();
-
 		interviewBeginRequestDto.getCategories().stream()
 			.map(categoryName -> categoryRepository.findByContent(categoryName)
-				.orElseThrow()) // exception 구현 필요
+				.orElseThrow(InterviewException.CategoryNotFoundException::new)) // 카테고리를 찾지 못했을 때 예외 발생
 			.forEach(category -> {
 				createInterviewCategory(interview, category);
 				categoryIdList.add(category.getId());
 			});
+
 		createInterviewQna(interview, categoryIdList);
 		return new InterviewBeginResponseDto(interview.getId());
 	}
 
+	/**
+	 * createInterviewQna 메서드
+	 * 인터뷰에 질문을 분배하고, 각 질문에 대한 InterviewQna를 생성합니다.
+	 *
+	 * @param interview 생성된 인터뷰 객체
+	 * @param categoryIdList 선택된 카테고리의 ID 리스트
+	 *
+	 * 처리 단계:
+	 * 1. 각 카테고리에 대해 분배할 질문 수를 계산합니다.
+	 * 2. 각 카테고리에 대해 랜덤으로 질문을 선택하여 InterviewQna를 생성합니다.
+	 * 3. 생성된 InterviewQna를 저장합니다.
+	 *
+	 * 예외 처리:
+	 *  - 질문 목록이 비어있거나, 질문 개수가 부족할 경우 InvalidCategoryException 예외 발생
+	 */
 	@Transactional
 	public void createInterviewQna(final Interview interview, final List<Long> categoryIdList) {
 		final Map<Long, Integer> categoryIdAndNumList = distributeQuestions(10, categoryIdList);
 		final List<QuestionCategory> questionCategoryList =
 			questionCategoryRepository.findRandByCategoryIdList(categoryIdAndNumList);
+
+		if (questionCategoryList.isEmpty() || questionCategoryList.size() < 10) {
+			throw new InterviewException.InvalidCategoryException();
+		} // 완성된 qna 수가 10개 미만이거나 비었을 경우 exception 던짐
 
 		List<InterviewQna> interviewQnaList = new ArrayList<>();
 
@@ -91,10 +124,32 @@ public class InterviewService {
 		interviewCategoryRepository.save(interviewCategory);
 	}
 
+	/**
+	 * getInterviews 메서드
+	 * 현재 로그인된 사용자의 모든 인터뷰 세션을 조회하고 반환합니다.
+	 *
+	 * 처리 단계:
+	 * 1. 사용자 인증 정보를 가져옵니다.
+	 * 2. 사용자의 프로필을 조회하고, 존재하지 않으면 예외를 던집니다.
+	 * 3. 사용자의 모든 인터뷰 세션을 조회합니다.
+	 * 4. 인터뷰 세션 리스트를 InterviewsResponseDto 형식으로 반환합니다.
+	 *
+	 * @return InterviewsResponseDto - 조회된 인터뷰 세션 정보를 포함한 응답 DTO
+	 */
 	@Transactional
 	public InterviewsResponseDto getInterviews() {
+
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-		Long userId = Long.parseLong(authentication.getName());
+		long userId;
+
+		try {
+			userId = Long.parseLong(authentication.getName()); // 추후 시큐리티 완성 후 맞게 수정 필요
+		} catch (NumberFormatException e) {
+			throw new InterviewException.ProfileNotFoundException(); // userId를 찾지 못했을 때 예외 발생
+		}
+
+		final Profile profile = profileRepository.findById(userId)
+			.orElseThrow(InterviewException.ProfileNotFoundException::new);
 
 		Optional<List<Interview>> interviews = interviewRepository.findAllByProfileId(userId);
 
@@ -117,8 +172,20 @@ public class InterviewService {
 		return interviewsResponseDto;
 	}
 
-	// 추후 answer set하는 부분을 setter가 아닌 서비스 로직을 통하여 변경 가능하도록 변경 예정
-	// answer
+	/**
+	 * getInterviewAnswer 메서드
+	 * 사용자가 인터뷰 질문에 답변을 제공한 후 답변을 저장하고, 모든 질문이 완료되었는지 확인합니다.
+	 *
+	 * @param interviewAnswerRequestDto 사용자가 제공한 답변 정보
+	 * @param interviewId 인터뷰 세션 ID
+	 *
+	 * 처리 단계:
+	 * 1. 인터뷰 세션을 조회하고, 없으면 예외를 던집니다.
+	 * 2. 사용자가 제공한 답변을 InterviewQna에 저장합니다.
+	 * 3. 모든 질문에 답변이 완료되었는지 확인하고, 완료되었으면 인터뷰 상태를 완료로 표시합니다.
+	 *
+	 * @return InterviewAnswerResponseDto - 모든 질문이 완료되었는지 여부를 포함한 응답 DTO
+	 */
 	@Transactional
 	public InterviewAnswerResponseDto getInterviewAnswer(InterviewAnswerRequestDto interviewAnswerRequestDto, Long interviewId){
 		Optional<Interview> interview = interviewRepository.findById(interviewId);
@@ -126,16 +193,19 @@ public class InterviewService {
 
 		if (interview.isPresent()) {
 			Interview interviewEntity = interview.get();
-			Optional<InterviewQna> interviewQna = interviewQnaRepository.findByInterviewIdAndQuestionId(
-				interviewId, interviewAnswerRequestDto.getQuestionIndex());
+			Optional<InterviewQna> interviewQna = Optional.ofNullable(interviewQnaRepository.findByInterviewIdAndQuestionId(
+					interviewId, interviewAnswerRequestDto.getQuestionIndex())
+				.orElseThrow(InterviewException.QuestionNotFoundException::new));
 			interviewQna.ifPresent(qna -> {
 				qna.setAnswer(interviewAnswerRequestDto.getAnswer());
 				interviewQnaRepository.save(qna);
-			}); // TODO : setter 리팩토링
+			});
+
+			// 모든 질문이 저장되었는지 홧인
 			List<InterviewQna> interviewQnaList = interviewQnaRepository.findAllByInterviewId(interviewId);
-			allAnswered = interviewQnaList.stream()
-				.allMatch(qna -> qna.getAnswer() != null);
+			allAnswered = interviewQnaList.stream().allMatch(qna -> qna.getAnswer() != null);
 			interviewEntity.setDone(allAnswered);
+
 			interviewRepository.save(interviewEntity);
 		}
 		return new InterviewAnswerResponseDto(allAnswered);
@@ -143,15 +213,28 @@ public class InterviewService {
 
 	@Transactional
 	public InterviewReportResponseDto createInterviewReport(InterviewReportCreateRequestDto interviewReportCreateRequestDto) {
+
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-		Long userId = Long.parseLong(authentication.getName());
+		long userId;
+
+		try {
+			userId = Long.parseLong(authentication.getName()); // 추후 시큐리티 완성 후 맞게 수정 필요
+		} catch (NumberFormatException e) {
+			throw new InterviewException.ProfileNotFoundException(); // userId를 찾지 못했을 때 예외 발생
+		}
+
 		Long interviewId = interviewReportCreateRequestDto.getSessionID();
-		Optional<Interview> interview = interviewRepository.findById(interviewId);
+		Optional<Interview> interview = Optional.ofNullable(interviewRepository.findById(interviewId)
+			.orElseThrow(InterviewException.InterviewNotFoundException::new));
 		InterviewReportResponseDto interviewReportResponseDto = new InterviewReportResponseDto();
 		if (interview.isPresent()) {
 
 			Interview interviewEntity = interview.get();
 			List<InterviewQna> qnaList = interviewQnaRepository.findAllByInterviewId(interviewId);
+
+			if (qnaList.isEmpty() || qnaList.size() < 10) {
+				throw new InterviewException.QuestionNotFoundException();
+			}
 
 			InterviewReportResponseDto reportDto = new InterviewReportResponseDto();
 			reportDto.setSessionID(interviewId);
@@ -161,8 +244,13 @@ public class InterviewService {
 				interviewQna -> {
 					Question question = interviewQna.getQuestionCategory().getQuestion();
 					String questionContent = question.getContent();
-					String answer = interviewQna.getAnswer(); // TODO: answer이 없을 경우, 예외 필요
-					// TODO: 레포트 생성하는 부분 처리 필요
+					if (questionContent == null || questionContent.isEmpty()) {
+						throw new InterviewException.QuestionNotFoundException();
+					}
+					String answer = interviewQna.getAnswer();
+					if (answer == null) {
+						throw new InterviewException.AnswerNotFoundException();
+					}
 					return new InterviewReportResponseDto.InterviewQnaReportDto(
 						questionContent, question.getId(), answer
 					);
@@ -176,33 +264,38 @@ public class InterviewService {
 	}
 
 	/**
+	 * distributeQuestions 메서드
+	 * 주어진 총 질문 수와 카테고리 목록을 기반으로, 각 카테고리에 분배할 질문 수를 계산합니다.
 	 *
-	 * @param totalQuestionsCount
-	 * @param categories
-	 * 세션 질문 수 n / 카테고리 수 m = 카테고리 별로 최소 들어가야할 질문 수
-	 * (전체 질문 수 현재 10개지만 추후 질문 수 확장 염두에 뒀으니까 그냥 n으로 둠)
+	 * @param totalQuestionsCount 세션에서 사용할 전체 질문 수 (현재 10개)
+	 * @param categories 사용할 카테고리 목록 (각 카테고리마다 최소 1개 이상의 질문이 할당됨)
 	 *
-	 * 세션 질문 수 n % 카테고리 수 m = 카테고리 별로 들어가야할 남은 질문 수
+	 * 분배 방식:
+	 * 1. 카테고리 개수(m)만큼 최소 질문 수를 각 카테고리에 1개씩 할당합니다.
+	 * 2. 나머지 질문 수는 자바의 Random 함수를 사용하여 랜덤하게 카테고리들에 분배합니다.
+	 *    - 남은 질문 수 = totalQuestionsCount - categories.size()
+	 *    - 각 카테고리에 1개씩 할당된 이후 남은 질문을 무작위로 카테고리에 추가 분배합니다.
 	 *
-	 * 남은 질문은 자바 Rand사용해서 랜덤한 카테고리 하나씩 for문 돌리면서 카운트 하나 씩 감소하면서 0이 될 때까지 돌림
-	 *
-	 * HashMap 형태로, <String, num>으로 카테고리, 개수 형태로 query 요청
-	 * @return
+	 * @return HashMap<Long, Integer> - 카테고리 ID와 해당 카테고리에 할당된 질문 수를 매핑하여 반환합니다.
 	 */
 	public Map<Long, Integer> distributeQuestions(int totalQuestionsCount, List<Long> categories){
-		// redis에서 totalQuestionsCount를 보관하면 성능도 좋을듯
 		int categoriesCount = categories.size();
 
-		// TODO: if (num of question > num of category) 일 경우 exception 필요
+		// 만약 전체 질문 수가 카테고리 수보다 적으면 예외
+		if (totalQuestionsCount < categoriesCount) {
+			throw new InterviewException.InvalidCategoryException();
+		}
 
 		Map<Long, Integer> questionsMap = new HashMap<>();
 
 		int remainQuestionsPerCategory = totalQuestionsCount - categoriesCount;
 
+		// 각 카테고리에 최소 1개씩 할당합니다.
 		for (Long category : categories) {
 			questionsMap.put(category, 1);
 		}
 
+		// 남은 질문을 랜덤하게 카테고리에 할당합니다.
 		for (int i = 0; i < remainQuestionsPerCategory; i++) {
 			Long randomCategory = categories.get(ThreadLocalRandom.current().nextInt());
 			questionsMap.put(randomCategory, questionsMap.get(randomCategory) + 1);

--- a/src/main/java/potato/onetake/global/exception/ExceptionHandlerController.java
+++ b/src/main/java/potato/onetake/global/exception/ExceptionHandlerController.java
@@ -13,7 +13,8 @@ import potato.onetake.global.exception.httpException.HttpErrorException;
  * CATEGORY_NOT_FOUND(2001, "카테고리를 찾지 못했습니다."),
  * PROFILE_NOT_FOUND(2002, "프로필을 찾지 못했습니다."),
  * QUESTION_NOT_FOUND(2003, "질문을 찾지 못했습니다."),
- * BOOKMARK_NOT_FOUND(2004, "북마크를 찾지 못했습니다.");
+ * ANSWER_NOT_FOUND(2004, "질문에 대한 답을 찾지 못했습니다."),
+ * INVALID_CATEGORY(2010, "질문 생성 중 카테고리에 문제가 발생했습니다.");
  */
 @RestControllerAdvice
 public class ExceptionHandlerController extends ResponseEntityExceptionHandler {
@@ -30,6 +31,7 @@ public class ExceptionHandlerController extends ResponseEntityExceptionHandler {
 		InterviewException.InterviewNotFoundException.class,
 		InterviewException.CategoryNotFoundException.class,
 		InterviewException.QuestionNotFoundException.class,
+		InterviewException.AnswerNotFoundException.class,
 	})
 	public ResponseEntity<String> handleInterviewFactorNotFoundException(final CustomException e) {
 		return ResponseEntity

--- a/src/main/java/potato/onetake/global/exception/ExceptionHandlerController.java
+++ b/src/main/java/potato/onetake/global/exception/ExceptionHandlerController.java
@@ -5,14 +5,40 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
-import potato.onetake.global.exception.httpException.HttpErrorCode;
+import potato.onetake.domain.Ineterview.exception.InterviewException;
 import potato.onetake.global.exception.httpException.HttpErrorException;
 
+/**
+ * INTERVIEW_NOT_FOUND(2000,"인터뷰 세션을 찾지 못했습니다."),
+ * CATEGORY_NOT_FOUND(2001, "카테고리를 찾지 못했습니다."),
+ * PROFILE_NOT_FOUND(2002, "프로필을 찾지 못했습니다."),
+ * QUESTION_NOT_FOUND(2003, "질문을 찾지 못했습니다."),
+ * BOOKMARK_NOT_FOUND(2004, "북마크를 찾지 못했습니다.");
+ */
 @RestControllerAdvice
 public class ExceptionHandlerController extends ResponseEntityExceptionHandler {
 
 	@ExceptionHandler(HttpErrorException.NoApiParamException.class)
 	public ResponseEntity<String> handleNoApiParamException(final CustomException e) {
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(e.toString());
+	}
+
+	@ExceptionHandler({
+		InterviewException.ProfileNotFoundException.class,
+		InterviewException.InterviewNotFoundException.class,
+		InterviewException.CategoryNotFoundException.class,
+		InterviewException.QuestionNotFoundException.class,
+	})
+	public ResponseEntity<String> handleInterviewFactorNotFoundException(final CustomException e) {
+		return ResponseEntity
+			.status(HttpStatus.NOT_FOUND)
+			.body(e.toString());
+	}
+
+	@ExceptionHandler(InterviewException.InvalidCategoryException.class)
+	public ResponseEntity<String> handleInvalidCategoryException(final CustomException e) {
 		return ResponseEntity
 			.status(HttpStatus.BAD_REQUEST)
 			.body(e.toString());


### PR DESCRIPTION
## 연관된 작업사항
- 인터뷰 관련 예외 처리 로직 구현
- `ExceptionHandlerController`에 인터뷰 관련 예외 핸들러 추가

## 작업내용
- **`InterviewErrorCode` Enum 생성:**
  - 인터뷰 세션, 카테고리, 프로필, 질문 관련 예외 코드 정의
    - `INTERVIEW_NOT_FOUND(2000, "인터뷰 세션을 찾지 못했습니다.")`
    - `CATEGORY_NOT_FOUND(2001, "카테고리를 찾지 못했습니다.")`
    - `PROFILE_NOT_FOUND(2002, "프로필을 찾지 못했습니다.")`
    - `QUESTION_NOT_FOUND(2003, "질문을 찾지 못했습니다.")`
    - 	`ANSWER_NOT_FOUND(2004, "질문에 대한 답을 찾지 못했습니다.")`
    - `INVALID_CATEGORY(2005, "질문 생성 중 카테고리에 문제가 발생했습니다.")`
  
- **`InterviewException` 클래스 구현:**
  - 인터뷰 관련 예외 처리를 위한 커스텀 예외 클래스 생성
    - `InterviewNotFoundException`
    - `CategoryNotFoundException`
    - `InvalidCategoryException`
    - `ProfileNotFoundException`
    - `QuestionNotFoundException`
    - `AnswerNotFoundException`

- **`createInterview` 메소드:**
  - 카테고리 조회 실패 시 `CategoryNotFoundException` 처리
  - 사용자 프로필 조회 실패 시 `ProfileNotFoundException` 처리

- **`createInterviewQna` 메소드:**
  - 질문 분배가 제대로 이루어지지 않으면 `InvalidCategoryException` 발생

- **`getInterviews` 메소드:**
  - 인터뷰 조회 실패 시 `InterviewNotFoundException` 처리

- **`getInterviewAnswer` 메소드:**
  - 질문이 존재하지 않거나 답변 저장 실패 시 `QuestionNotFoundException` 처리

- **`createInterviewReport` 메소드:**
  - 인터뷰가 없거나 답변이 없는 경우 `InterviewNotFoundException` 또는 `QuestionNotFoundException` 처리
  - 답변이 빈 객체가 아닌 NULL일 경우 (인터뷰 생성은 인터뷰가 끝난 시점에 진행) `AnswerNotFoundException` 처리

- **`ExceptionHandlerController` 예외 핸들러 추가:**
  - `InterviewNotFoundException`, `CategoryNotFoundException`, `ProfileNotFoundException`, `QuestionNotFoundException`, `AnswerNotFoundException` 발생 시 `404 Not Found` 응답 처리
  - `InvalidCategoryException` 발생 시 `400 Bad Request` 응답 처리

## Reference