### PR TITLE
:art: improve logics and structures of Interview Domain

### DIFF
--- a/src/main/java/potato/onetake/domain/Content/domain/Category.java
+++ b/src/main/java/potato/onetake/domain/Content/domain/Category.java
@@ -3,16 +3,15 @@ package potato.onetake.domain.Content.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
 import potato.onetake.global.BaseEntity.BaseEntity;
 
 @Entity
 @Getter
 @Setter
-@NoArgsConstructor
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name="category")
 public class Category extends BaseEntity {

--- a/src/main/java/potato/onetake/domain/Content/domain/Question.java
+++ b/src/main/java/potato/onetake/domain/Content/domain/Question.java
@@ -3,16 +3,15 @@ package potato.onetake.domain.Content.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
 import potato.onetake.global.BaseEntity.BaseEntity;
 
 @Entity
 @Getter
 @Setter
-@NoArgsConstructor
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name="Question")
 public class Question extends BaseEntity {

--- a/src/main/java/potato/onetake/domain/Content/domain/QuestionCategory.java
+++ b/src/main/java/potato/onetake/domain/Content/domain/QuestionCategory.java
@@ -4,16 +4,15 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
 import potato.onetake.global.BaseEntity.BaseEntity;
 
 @Entity
 @Getter
 @Setter
-@NoArgsConstructor
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name="question_category")
 public class QuestionCategory extends BaseEntity {

--- a/src/main/java/potato/onetake/domain/Ineterview/api/interviewController.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/api/interviewController.java
@@ -3,6 +3,7 @@ package potato.onetake.domain.Ineterview.api;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import potato.onetake.domain.Ineterview.domain.Interview;
 import potato.onetake.domain.Ineterview.dto.*;
 import potato.onetake.domain.Ineterview.service.InterviewService;
 
@@ -15,13 +16,14 @@ public class interviewController {
 
 	@GetMapping("/")
 	public ResponseEntity<InterviewsResponseDto> findAllInterviews() {
-		InterviewsResponseDto interviewsResponseDto = interviewService.getInterviews();
+		InterviewsResponseDto interviewsResponseDto = interviewService.findAllInterviews();
 		return ResponseEntity.ok(interviewsResponseDto);
 	}
 
 	@PostMapping("/")
 	public ResponseEntity<InterviewBeginResponseDto> createInterviewSession(InterviewBeginRequestDto requestDto) {
-		InterviewBeginResponseDto interviewBeginResponseDto = interviewService.createInterview(requestDto);
+		Interview interview = interviewService.createInterview(requestDto.getTitle());
+		InterviewBeginResponseDto interviewBeginResponseDto = new InterviewBeginResponseDto();
 		return ResponseEntity.ok(interviewBeginResponseDto);
 	}
 
@@ -37,7 +39,7 @@ public class interviewController {
 		InterviewAnswerRequestDto  interviewAnswerRequestDto, @PathVariable String sessionID) {
 		Long interviewId = Long.parseLong(sessionID);
 		InterviewAnswerResponseDto interviewAnswer =
-			interviewService.getInterviewAnswer(interviewAnswerRequestDto, interviewId);
+			interviewService.updateAnswer(interviewAnswerRequestDto, interviewId);
 		return ResponseEntity.ok(interviewAnswer);
 	}
 

--- a/src/main/java/potato/onetake/domain/Ineterview/dao/InterviewRepository.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/dao/InterviewRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 
 @Repository
 public interface InterviewRepository extends JpaRepository<Interview, Long> {
-	Optional<List<Interview>> findAllByProfileAlias(String profileAlias);
+	Optional<List<Interview>> findAllByProfileId(Long profileId);
 }

--- a/src/main/java/potato/onetake/domain/Ineterview/domain/Interview.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/domain/Interview.java
@@ -1,9 +1,8 @@
 package potato.onetake.domain.Ineterview.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
 import potato.onetake.domain.Position.domain.Profile;
 import potato.onetake.global.BaseEntity.BaseEntity;
 
@@ -12,7 +11,8 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Setter
-@NoArgsConstructor
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name="interview")
 public class Interview extends BaseEntity {
 
@@ -26,15 +26,4 @@ public class Interview extends BaseEntity {
 	@Column(name = "done", nullable = false)
 	private boolean done;
 
-	public Interview(Profile profile, String title) {
-		this.profile = profile;
-		this.title = title;
-		this.done = false;
-	}
-
-	public Interview(Profile profile, String title, boolean done) {
-		this.profile = profile;
-		this.title = title;
-		this.done = done;
-	}
 }

--- a/src/main/java/potato/onetake/domain/Ineterview/domain/InterviewCategory.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/domain/InterviewCategory.java
@@ -5,16 +5,17 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
 import potato.onetake.domain.Content.domain.Category;
 import potato.onetake.global.BaseEntity.BaseEntity;
 
 @Entity
 @Getter
 @Setter
-@NoArgsConstructor
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Table(name="interview_category")
 public class InterviewCategory extends BaseEntity {
 
@@ -25,10 +26,5 @@ public class InterviewCategory extends BaseEntity {
 	@ManyToOne()
 	@JoinColumn(name = "category_id", referencedColumnName = "id")
 	private Category category;
-
-	public InterviewCategory(final Interview interview, final Category category) {
-		this.interview = interview;
-		this.category = category;
-	}
 
 }

--- a/src/main/java/potato/onetake/domain/Ineterview/domain/InterviewQna.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/domain/InterviewQna.java
@@ -1,9 +1,8 @@
 package potato.onetake.domain.Ineterview.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
 import potato.onetake.domain.Content.domain.Question;
 import potato.onetake.domain.Content.domain.QuestionCategory;
 import potato.onetake.global.BaseEntity.BaseEntity;
@@ -11,7 +10,8 @@ import potato.onetake.global.BaseEntity.BaseEntity;
 @Entity
 @Getter
 @Setter
-@NoArgsConstructor
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name="interview_qna")
 public class InterviewQna extends BaseEntity {
 
@@ -26,14 +26,4 @@ public class InterviewQna extends BaseEntity {
 	@Column(name = "answer", nullable = true)
 	private String answer;
 
-	public InterviewQna(final Interview interview, final QuestionCategory questionCategory) {
-		this.interview = interview;
-		this.questionCategory = questionCategory;
-	}
-
-	public  InterviewQna(final Interview interview, final QuestionCategory questionCategory, final String answer) {
-		this.interview = interview;
-		this.questionCategory = questionCategory;
-		this.answer = answer;
-	}
 }

--- a/src/main/java/potato/onetake/domain/Ineterview/domain/InterviewResult.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/domain/InterviewResult.java
@@ -1,6 +1,7 @@
 package potato.onetake.domain.Ineterview.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,6 +11,7 @@ import potato.onetake.global.BaseEntity.BaseEntity;
 @Entity
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
 @Table(name="interview_result")
 public class InterviewResult extends BaseEntity {

--- a/src/main/java/potato/onetake/domain/Ineterview/dto/InterviewAnswerRequestDto.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/dto/InterviewAnswerRequestDto.java
@@ -1,10 +1,12 @@
 package potato.onetake.domain.Ineterview.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class InterviewAnswerRequestDto {

--- a/src/main/java/potato/onetake/domain/Ineterview/dto/InterviewAnswerResponseDto.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/dto/InterviewAnswerResponseDto.java
@@ -1,11 +1,9 @@
 package potato.onetake.domain.Ineterview.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Setter

--- a/src/main/java/potato/onetake/domain/Ineterview/dto/InterviewBeginRequestDto.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/dto/InterviewBeginRequestDto.java
@@ -1,12 +1,14 @@
 package potato.onetake.domain.Ineterview.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class InterviewBeginRequestDto {

--- a/src/main/java/potato/onetake/domain/Ineterview/dto/InterviewBeginResponseDto.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/dto/InterviewBeginResponseDto.java
@@ -1,13 +1,11 @@
 package potato.onetake.domain.Ineterview.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 @Setter
 public class InterviewBeginResponseDto {
 	private Long sessionID;

--- a/src/main/java/potato/onetake/domain/Ineterview/dto/InterviewQuestionResponseDto.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/dto/InterviewQuestionResponseDto.java
@@ -2,6 +2,7 @@ package potato.onetake.domain.Ineterview.dto;
 
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -10,7 +11,7 @@ import java.util.List;
 @Setter
 @Builder
 public class InterviewQuestionResponseDto {
-	private List<QuestionDto> questions;
+	private List<QuestionDto> questions = new ArrayList<>();
 
 	public void addQuestion(QuestionDto question) {
 		questions.add(question);

--- a/src/main/java/potato/onetake/domain/Ineterview/dto/InterviewsResponseDto.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/dto/InterviewsResponseDto.java
@@ -1,14 +1,12 @@
 package potato.onetake.domain.Ineterview.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
 @Setter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class InterviewsResponseDto {
@@ -16,6 +14,7 @@ public class InterviewsResponseDto {
 
 	@Getter
 	@Setter
+	@Builder
 	@AllArgsConstructor
 	@NoArgsConstructor
 	public static class InterviewSessionDto{

--- a/src/main/java/potato/onetake/domain/Ineterview/exception/InterviewErrorCode.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/exception/InterviewErrorCode.java
@@ -13,6 +13,7 @@ public enum InterviewErrorCode implements ErrorCode {
 	PROFILE_NOT_FOUND(2002, "프로필을 찾지 못했습니다."),
 	QUESTION_NOT_FOUND(2003, "질문을 찾지 못했습니다."),
 	ANSWER_NOT_FOUND(2004, "질문에 대한 답을 찾지 못했습니다."),
+	DUPLICATED_ANSWER(2005, "이미 답변한 질문입니다."),
 	INVALID_CATEGORY(2010, "질문 생성 중 카테고리에 문제가 발생했습니다.");
 
 	private final int errorCode;

--- a/src/main/java/potato/onetake/domain/Ineterview/exception/InterviewException.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/exception/InterviewException.java
@@ -34,6 +34,10 @@ public class InterviewException extends CustomException {
 		public QuestionNotFoundException() { super(InterviewErrorCode.QUESTION_NOT_FOUND); }
 	}
 
+	public static class DuplicateQuestionException extends InterviewException {
+		public DuplicateQuestionException() { super(InterviewErrorCode.DUPLICATED_ANSWER); }
+	}
+
 	public static class AnswerNotFoundException extends InterviewException {
 		public AnswerNotFoundException() { super(InterviewErrorCode.ANSWER_NOT_FOUND); }
 	}

--- a/src/main/java/potato/onetake/domain/Ineterview/service/InterviewService.java
+++ b/src/main/java/potato/onetake/domain/Ineterview/service/InterviewService.java
@@ -24,6 +24,7 @@ import potato.onetake.domain.Position.domain.Profile;
 
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -38,72 +39,62 @@ public class InterviewService {
 	private final InterviewCategoryRepository interviewCategoryRepository;
 	private final QuestionCategoryRepository questionCategoryRepository;
 
-	/**
-	 * createInterview 메서드
-	 * 인터뷰 세션을 생성하고, 사용자의 프로필과 선택된 카테고리 기반으로 인터뷰를 구성합니다.
-	 *
-	 * @param interviewBeginRequestDto 사용자로부터 받은 인터뷰 시작 요청 정보
-	 *  - 사용자 프로필을 조회하고, 선택된 카테고리로 인터뷰를 생성
-	 *  - 각 카테고리에 대해 InterviewCategory 및 InterviewQna를 생성
-	 *
-	 * 처리 단계:
-	 * 1. 시큐리티 컨텍스트에서 로그인된 사용자 ID를 가져옵니다.
-	 * 2. 사용자 프로필을 조회하고, 프로필이 없으면 예외를 던집니다.
-	 * 3. 주어진 제목으로 인터뷰 세션을 생성하고 저장합니다.
-	 * 4. 사용자가 선택한 카테고리로 InterviewCategory를 생성하여 저장합니다.
-	 * 5. 각 카테고리에 속한 질문들로 InterviewQna를 생성하여 인터뷰와 연결합니다.
-	 *
-	 * @return InterviewBeginResponseDto - 생성된 인터뷰 세션 ID를 포함한 응답 DTO를 반환
-	 */
-	@Transactional
-	public InterviewBeginResponseDto createInterview(final InterviewBeginRequestDto interviewBeginRequestDto) {
-
+	private String getUserIdFromSecurityContext() {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-		String userId;
+
 		try {
-			userId = authentication.getName(); // 추후 시큐리티 완성 후 맞게 수정 필요
+			return authentication.getName(); // 추후 시큐리티 완성 후 맞게 수정 필요
 		} catch (NumberFormatException e) {
 			throw new InterviewException.ProfileNotFoundException(); // userId를 찾지 못했을 때 예외 발생
 		}
-
-		final Profile profile = profileRepository.findByAlias(userId)
-			.orElseThrow(InterviewException.ProfileNotFoundException::new);
-
-		Interview interview = new Interview(profile, interviewBeginRequestDto.getTitle());
-		interviewRepository.save(interview);
-
-		List<Long> categoryIdList = new ArrayList<Long>();
-		interviewBeginRequestDto.getCategories().stream()
-			.map(categoryName -> categoryRepository.findByContent(categoryName)
-				.orElseThrow(InterviewException.CategoryNotFoundException::new)) // 카테고리를 찾지 못했을 때 예외 발생
-			.forEach(category -> {
-				createInterviewCategory(interview, category);
-				categoryIdList.add(category.getId());
-			});
-
-		Map<Long, Integer> categoryIdAndNumList = distributeQuestions(10, categoryIdList);
-		createInterviewQna(interview, categoryIdAndNumList);
-		return new InterviewBeginResponseDto(interview.getId());
 	}
 
-	/**
-	 * createInterviewQna 메서드
-	 * 인터뷰에 질문을 분배하고, 각 질문에 대한 InterviewQna를 생성합니다.
-	 *
-	 * @param interview 생성된 인터뷰 객체
-	 * @param categoryIdAndNumList 선택된 카테고리의 ID와 카테고리 별 질문 개수 리스트
-	 *
-	 * 처리 단계:
-	 * 1. 각 카테고리에 대해 분배할 질문 수를 계산합니다.
-	 * 2. 각 카테고리에 대해 랜덤으로 질문을 선택하여 InterviewQna를 생성합니다.
-	 * 3. 생성된 InterviewQna를 저장합니다.
-	 *
-	 * 예외 처리:
-	 *  - 질문 목록이 비어있거나, 질문 개수가 부족할 경우 InvalidCategoryException 예외 발생
-	 */
+	private Profile getProfileByUserId(String userId) {
+		return profileRepository.findByAlias(userId)
+			.orElseThrow(InterviewException.ProfileNotFoundException::new);
+	}
+
 	@Transactional
-	public List<InterviewQna> createInterviewQna(final Interview interview,
-												 final Map<Long, Integer> categoryIdAndNumList) {
+	public Interview createInterview(String interviewTitle) {
+
+		String userId = getUserIdFromSecurityContext();
+		Profile profile = getProfileByUserId(userId);
+
+		Interview interview = Interview.builder()
+			.profile(profile)
+			.title(interviewTitle)
+			.done(false)
+			.build();
+
+		interviewRepository.save(interview);
+
+		return interview;
+	}
+
+	public List<Long> createInterviewCategories(Long interviewId, List<String> categoryNames) {
+		Interview interview = interviewRepository.findById(interviewId)
+			.orElseThrow(InterviewException.InterviewNotFoundException::new);
+
+		return categoryNames.stream()
+			.map(categoryName -> categoryRepository.findByContent(categoryName)
+				.orElseThrow(InterviewException.CategoryNotFoundException::new))
+			.map(category -> {
+				InterviewCategory interviewCategory = createInterviewCategory(interview, category);
+				return interviewCategory.getCategory().getId();})
+			.collect(Collectors.toList());
+	}
+
+	public void createInterviewQuestions(Long interviewId, List<Long> categoryIds) {
+		Interview interview = interviewRepository.findById(interviewId)
+			.orElseThrow(InterviewException.InterviewNotFoundException::new);
+		Map<Long, Integer> categoryIdAndNumList = distributeQuestions(10, categoryIds);
+
+		List<QuestionCategory> questionCategoryList = createQuestionCategoryList(categoryIdAndNumList);
+
+		createInterviewQna(interview, questionCategoryList);
+	}
+
+	public List<QuestionCategory> createQuestionCategoryList(final Map<Long, Integer> categoryIdAndNumList) {
 		final List<QuestionCategory> questionCategoryResultList =
 			questionCategoryRepository.findRandByCategoryIdList(categoryIdAndNumList);
 
@@ -111,10 +102,21 @@ public class InterviewService {
 			throw new InterviewException.InvalidCategoryException();
 		} // 완성된 qna 수가 10개 미만이거나 비었을 경우 exception 던짐
 
+		return questionCategoryResultList;
+	}
+
+	@Transactional
+	public List<InterviewQna> createInterviewQna(final Interview interview,
+												 final List<QuestionCategory> questionCategoryList) {
+
 		List<InterviewQna> interviewQnaList = new ArrayList<>();
 
-		questionCategoryResultList.forEach(questionCategory ->
-			interviewQnaList.add(new InterviewQna(interview, questionCategory)));
+		questionCategoryList.forEach(questionCategory ->
+			interviewQnaList.add(
+				InterviewQna.builder()
+				.interview(interview)
+				.questionCategory(questionCategory)
+				.build()));
 
 		interviewQnaRepository.saveAll(interviewQnaList);
 
@@ -141,38 +143,30 @@ public class InterviewService {
 	 * @return InterviewsResponseDto - 조회된 인터뷰 세션 정보를 포함한 응답 DTO
 	 */
 	@Transactional
-	public InterviewsResponseDto getInterviews() {
+	public InterviewsResponseDto findAllInterviews() {
 
-		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-		String userId;
-		try {
-			userId = authentication.getName(); // 추후 시큐리티 완성 후 맞게 수정 필요
-		} catch (NumberFormatException e) {
-			throw new InterviewException.ProfileNotFoundException(); // userId를 찾지 못했을 때 예외 발생
-		}
+		String userId = getUserIdFromSecurityContext();
+		Profile profile = getProfileByUserId(userId);
 
-		final Profile profile = profileRepository.findByAlias(userId)
-			.orElseThrow(InterviewException.ProfileNotFoundException::new);
+		Optional<List<Interview>> interviews = interviewRepository.findAllByProfileId(profile.getId());
 
-		Optional<List<Interview>> interviews = interviewRepository.findAllByProfileAlias(profile.getAlias());
-
-		InterviewsResponseDto interviewsResponseDto = new InterviewsResponseDto();
+		List<InterviewsResponseDto.InterviewSessionDto> sessionDtos = new ArrayList<>();
 
 		if (interviews.isPresent()) {
 			List<Interview> interviewList = interviews.get();
-			List<InterviewsResponseDto.InterviewSessionDto> sessionDtos = interviewList.stream()
+			sessionDtos = interviewList.stream()
 				.map(interview -> new InterviewsResponseDto.InterviewSessionDto(
 					interview.getId(),
 					interview.getTitle(),
-					interview.getCreatedAt() != null ? interview.getCreatedAt().toString() : "No Creation Date",
+					interview.getCreatedAt().toString(),
 					0,
 					interview.isDone()
 				)).toList();
-
-			interviewsResponseDto.setInterviewSessions(sessionDtos); // TODO : 리팩토링
 		}
 
-		return interviewsResponseDto;
+		return InterviewsResponseDto.builder()
+			.interviewSessions(sessionDtos)
+			.build();
 	}
 
 	/**
@@ -190,29 +184,34 @@ public class InterviewService {
 	 * @return InterviewAnswerResponseDto - 모든 질문이 완료되었는지 여부를 포함한 응답 DTO
 	 */
 	@Transactional
-	public InterviewAnswerResponseDto getInterviewAnswer(InterviewAnswerRequestDto interviewAnswerRequestDto, Long interviewId){
-		Optional<Interview> interview = interviewRepository.findById(interviewId);
+	public InterviewAnswerResponseDto updateAnswer(InterviewAnswerRequestDto interviewAnswerRequestDto, Long interviewId){
+
+		updateInterviewQnaByAnswer(interviewAnswerRequestDto);
+
+		return InterviewAnswerResponseDto.builder().done(isAllAnswered(interviewId)).build();
+	}
+
+	@Transactional
+	public boolean isAllAnswered(Long interviewId) {
 		boolean allAnswered = false;
+		List<InterviewQna> interviewQnaList = interviewQnaRepository.findAllByInterviewId(interviewId);
+		allAnswered = interviewQnaList.stream().allMatch(qna -> qna.getAnswer() != null);
 
-		if (interview.isPresent()) {
-			Interview interviewEntity = interview.get();
-			Optional<InterviewQna> interviewQna = Optional.ofNullable(interviewQnaRepository
-				.findByInterviewIdAndQuestionCategoryId(
-					interviewId, interviewAnswerRequestDto.getQuestionIndex())
-				.orElseThrow(InterviewException.QuestionNotFoundException::new));
-			interviewQna.ifPresent(qna -> {
-				qna.setAnswer(interviewAnswerRequestDto.getAnswer());
-				interviewQnaRepository.save(qna);
-			});
+		return allAnswered;
+	}
 
-			// 모든 질문이 저장되었는지 홧인
-			List<InterviewQna> interviewQnaList = interviewQnaRepository.findAllByInterviewId(interviewId);
-			allAnswered = interviewQnaList.stream().allMatch(qna -> qna.getAnswer() != null);
-			interviewEntity.setDone(allAnswered);
+	@Transactional
+	public InterviewQna updateInterviewQnaByAnswer (InterviewAnswerRequestDto interviewAnswerRequestDto) {
+		Long qnaId = interviewAnswerRequestDto.getQuestionIndex();
+		String requestedAnswer = interviewAnswerRequestDto.getAnswer();
 
-			interviewRepository.save(interviewEntity);
-		}
-		return new InterviewAnswerResponseDto(allAnswered);
+		InterviewQna interviewQna = interviewQnaRepository
+			.findById(qnaId)
+			.orElseThrow(InterviewException.QuestionNotFoundException::new);
+
+		interviewQna.setAnswer(requestedAnswer);
+		interviewQnaRepository.save(interviewQna);
+		return interviewQna;
 	}
 
 	/**

--- a/src/main/java/potato/onetake/global/BaseEntity/BaseEntity.java
+++ b/src/main/java/potato/onetake/global/BaseEntity/BaseEntity.java
@@ -2,6 +2,8 @@ package potato.onetake.global.BaseEntity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -11,7 +13,9 @@ import java.util.Date;
 
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
+@NoArgsConstructor
 @Getter
+@SuperBuilder
 public abstract class BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/potato/onetake/global/exception/ExceptionHandlerController.java
+++ b/src/main/java/potato/onetake/global/exception/ExceptionHandlerController.java
@@ -39,6 +39,13 @@ public class ExceptionHandlerController extends ResponseEntityExceptionHandler {
 			.body(e.toString());
 	}
 
+	@ExceptionHandler(InterviewException.DuplicateQuestionException.class)
+	public ResponseEntity<String> handleDuplicateQuestionException(final CustomException e) {
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(e.toString());
+	}
+
 	@ExceptionHandler(InterviewException.InvalidCategoryException.class)
 	public ResponseEntity<String> handleInvalidCategoryException(final CustomException e) {
 		return ResponseEntity

--- a/src/test/java/potato/onetake/Interview/InterviewEntityTest.java
+++ b/src/test/java/potato/onetake/Interview/InterviewEntityTest.java
@@ -35,7 +35,8 @@ public class InterviewEntityTest {
 		when(mockProfile.getId()).thenReturn(1L);
 
 		// Given
-		Interview interview = new Interview(mockProfile, "interview title");
+		Interview interview = Interview.builder().profile(mockProfile).title("interview title").build();
+//		Interview interview = new Interview(mockProfile, "interview title");
 		entityManager.persist(interview);
 
 		System.out.printf("interview title: %s\n", interview.getTitle());

--- a/src/test/java/potato/onetake/Interview/InterviewServiceTest.java
+++ b/src/test/java/potato/onetake/Interview/InterviewServiceTest.java
@@ -6,13 +6,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.annotation.Rollback;
 import potato.onetake.domain.Content.dao.CategoryRepository;
 import potato.onetake.domain.Content.dao.QuestionCategoryRepository;
-import potato.onetake.domain.Content.dao.QuestionRepository;
 import potato.onetake.domain.Content.domain.Category;
 import potato.onetake.domain.Content.domain.Question;
 import potato.onetake.domain.Content.domain.QuestionCategory;
+import potato.onetake.domain.Ineterview.dao.InterviewCategoryRepository;
+import potato.onetake.domain.Ineterview.dao.InterviewQnaRepository;
 import potato.onetake.domain.Ineterview.dao.InterviewRepository;
 import potato.onetake.domain.Ineterview.domain.Interview;
 import potato.onetake.domain.Ineterview.domain.InterviewCategory;
@@ -26,27 +26,27 @@ import org.springframework.security.core.context.SecurityContext;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class InterviewServiceTest {
 
-	private static int numOfCategory = 5;
-	private static int numOfQuestion = 20;
-
 	@Mock private InterviewRepository interviewRepository;
 	@Mock private ProfileRepository profileRepository;
 	@Mock private CategoryRepository categoryRepository;
-	@Mock private QuestionRepository questionRepository;
+	@Mock private InterviewCategoryRepository interviewCategoryRepository;
 	@Mock private QuestionCategoryRepository questionCategoryRepository;
+	@Mock private InterviewQnaRepository interviewQnaRepository;
 
 	@InjectMocks private InterviewService interviewService;
 
-	@BeforeEach
-	public void setup() {
+	@Test
+	@DisplayName("인터뷰 엔티티 생성 테스트")
+	public void createInterviewTest() {
+		// Given
 		// Create a mock authentication object
 		Authentication authentication = mock(Authentication.class);
 		when(authentication.getName()).thenReturn("testUser");
@@ -57,115 +57,203 @@ public class InterviewServiceTest {
 
 		// Set the mock SecurityContext in the SecurityContextHolder
 		SecurityContextHolder.setContext(securityContext);
-	}
 
-	@Test
-	@DisplayName("인터뷰 생성 테스트")
-	public void createInterviewTest() {
-		// Given
-		InterviewBeginRequestDto interviewBeginRequestDto =
-			new InterviewBeginRequestDto(
-				"test title",
-				Arrays.asList("Test Category 1", "Test Category 2", "Test Category 3"));
+		// Profile mocking
+		Profile testProfile = new Profile("testUser");
+		when(profileRepository.findByAlias("testUser")).thenReturn(Optional.of(testProfile));
 
-		// Expected
-
-		InterviewBeginResponseDto expectedResult = new InterviewBeginResponseDto(1L);
-		when(interviewService.createInterview(interviewBeginRequestDto)).thenReturn(expectedResult);
+		String interviewTitle = "Test Interview";
 
 		// When
-		InterviewBeginResponseDto interviewBeginResponseDto =
-			interviewService.createInterview(interviewBeginRequestDto);
+		Interview actualInterview =
+			interviewService.createInterview(interviewTitle);
 
 		//Then
-		Assertions.assertNotNull(interviewBeginResponseDto.getSessionID());
-		Assertions.assertEquals(interviewBeginResponseDto.getSessionID(), expectedResult.getSessionID());
+		Assertions.assertNotNull(actualInterview.getTitle());
+		Assertions.assertEquals(interviewTitle, actualInterview.getTitle());
 	}
 
 	@Test
 	@DisplayName("InterviewCategory 생성 테스트")
 	public void createInterviewCategoryTest() {
 		// Given
-		Profile profile = new Profile("Test Profile");
-		when(profileRepository.save(any(Profile.class))).thenReturn(profile);
+		Interview interview = Interview.builder()
+			.id(1L)
+			.title("test Interview")
+			.done(false)
+			.build();
 
-		Category category = new Category("Test Category");
-		when(categoryRepository.save(any(Category.class))).thenReturn(category);
-
-		Interview interview = new Interview(profile, "test");
-		when(interviewRepository.save(any(Interview.class))).thenReturn(interview);
-
-		// Expected
-		InterviewCategory expectedResult = new InterviewCategory(interview, category);
-		when(interviewService.createInterviewCategory(interview, category)).thenReturn(expectedResult);
+		Category category = Category.builder()
+			.id(1L)
+			.content("test Category")
+			.build();
 
 		// When
 		InterviewCategory interviewCategory = interviewService.createInterviewCategory(interview, category);
 
+		// Then (기대하는 결과 확인)
+		Assertions.assertNotNull(interviewCategory, "생성된 InterviewCategory는 null이어서는 안 됩니다.");
+		Assertions.assertEquals(interview, interviewCategory.getInterview(), "Interview가 일치해야 합니다.");
+		Assertions.assertEquals(category, interviewCategory.getCategory(), "Category가 일치해야 합니다.");
+	}
+
+	@Test
+	@DisplayName("카테고리 별 질문 리스트 생성 테스트")
+	void createQuestionCategoryListTest() {
+		// refer : List<QuestionCategory> createQuestionCategoryList(final Map<Long, Integer> categoryIdAndNumList)
+		// Given
+		Map<Long, Integer> mockedCategoryIdAndNumList = Map.of(
+			1L, 3,
+			2L, 4,
+			3L, 3
+		);
+
+		List<QuestionCategory> mockedQuestionCategoryList = new ArrayList<>(List.of());
+		mockedCategoryIdAndNumList.forEach(
+			(id, num) -> {
+				for (int i = 0; i < num; i++) {
+					mockedQuestionCategoryList.add(
+						QuestionCategory.builder()
+							.category(Category.builder().content("test category " + id).build())
+							.question(Question.builder().content("test question " + i).build())
+							.build()
+					);
+				}
+			});
+
+		// When
+		when(questionCategoryRepository.findRandByCategoryIdList(mockedCategoryIdAndNumList))
+			.thenReturn(mockedQuestionCategoryList);
+
+		// When
+		List<QuestionCategory> actualQuestionCategoryList =
+			interviewService.createQuestionCategoryList(mockedCategoryIdAndNumList);
+
 		// Then
-		Assertions.assertNotNull(interviewCategory);
-		Assertions.assertEquals(expectedResult.getId(), interviewCategory.getId());
-		Assertions.assertEquals(expectedResult.getInterview(), interviewCategory.getInterview());
-		Assertions.assertEquals(expectedResult.getCategory(), interviewCategory.getCategory());
+		Assertions.assertNotNull(actualQuestionCategoryList);
+		Assertions.assertEquals(mockedQuestionCategoryList.size(), actualQuestionCategoryList.size());
+	}
+
+	// 이거 보니까 pk 문제 때문에 그런 것 같은데 최대한 pk배제해서 테스트 할 수 있는 방법 찾아봐야 할 듯
+	@Test
+	@DisplayName("질문 생성 테스트")
+	void createInterviewQnaTest() {
+		// Given
+		// Mocked interview
+		Interview interview = Interview.builder()
+			.title("test Interview")
+			.done(false)
+			.build();
+		// Mocked QuestionCategory
+		Map<Long, Integer> mockedCategoryIdAndNumList = Map.of(
+			1L, 3,
+			2L, 4,
+			3L, 3
+		);
+		List<InterviewQna> expectedInterviewQnas = new ArrayList<>(List.of());
+		List<QuestionCategory> mockedQuestionCategoryList = new ArrayList<>(List.of());
+		mockedCategoryIdAndNumList.forEach(
+			(id, num) -> {
+				for (int i = 0; i < num; i++) {
+					QuestionCategory mockedQuestionCategory = QuestionCategory.builder()
+						.category(Category.builder().content("test category " + id).build())
+						.question(Question.builder().content("test question " + i).build())
+						.build();
+					mockedQuestionCategoryList.add(mockedQuestionCategory);
+					InterviewQna mockedInterviewQna = InterviewQna.builder()
+						.interview(interview)
+						.questionCategory(mockedQuestionCategory)
+						.build();
+					expectedInterviewQnas.add(mockedInterviewQna);
+				}
+			});
+
+		when(interviewQnaRepository.saveAll(anyList())).thenReturn(expectedInterviewQnas);
+
+		// When
+		List<InterviewQna> actualInterviewQnas =
+			interviewService.createInterviewQna(interview, mockedQuestionCategoryList);
+
+		// Then
+		Assertions.assertNotNull(actualInterviewQnas);
+		Assertions.assertEquals(mockedQuestionCategoryList.size(), actualInterviewQnas.size());
+		for (int i = 0; i < expectedInterviewQnas.size(); i++) {
+			InterviewQna expectedInterviewQna = expectedInterviewQnas.get(i);
+			InterviewQna actualInterviewQna = actualInterviewQnas.get(i);
+			Assertions.assertEquals(
+				expectedInterviewQna.getInterview().getTitle(),
+				actualInterviewQna.getInterview().getTitle());
+			Assertions.assertEquals(
+				expectedInterviewQna.getQuestionCategory().getCategory().getContent(),
+				actualInterviewQna.getQuestionCategory().getCategory().getContent());
+			Assertions.assertEquals(
+				expectedInterviewQna.getQuestionCategory().getQuestion().getContent(),
+				actualInterviewQna.getQuestionCategory().getQuestion().getContent()
+			);
+		}
 	}
 
 	@Test
 	@DisplayName("인터뷰 전체 조회")
-	public void getInterviewTest() {
+	public void findAllInterviewsTest() {
 		// Given
-		Profile profile = new Profile("testUser");
+		// Create a mock authentication object
+		Authentication authentication = mock(Authentication.class);
+		when(authentication.getName()).thenReturn("testUser");
 
-		// Mock ProfileRepository가 Profile 객체를 반환하도록 설정
-		when(profileRepository.findByAlias(anyString())).thenReturn(Optional.of(profile));
+		// Create a mock SecurityContext and set the authentication object
+		SecurityContext securityContext = mock(SecurityContext.class);
+		when(securityContext.getAuthentication()).thenReturn(authentication);
 
-		// 인터뷰 Mock 데이터 설정
-		List<Interview> mockInterviews = new ArrayList<>();
-		List<InterviewsResponseDto.InterviewSessionDto> interviewSessionDtosList = new ArrayList<>();
- 		for (int i = 0; i < 5; i++) {
-			Interview interview = new Interview(profile, "test interview " + i);
-			InterviewsResponseDto.InterviewSessionDto interviewSessionDto =
-				new InterviewsResponseDto.InterviewSessionDto(
-					interview.getId(),
-					interview.getTitle(),
-					interview.getCreatedAt() != null ? interview.getCreatedAt().toString() : "No Creation Date",
-					0,
-					interview.isDone()
-				);
-			interviewSessionDtosList.add(interviewSessionDto);
-			mockInterviews.add(interview);
+		// Set the mock SecurityContext in the SecurityContextHolder
+		SecurityContextHolder.setContext(securityContext);
+
+		// Profile mocking
+		Profile testProfile = new Profile("testUser");
+		when(profileRepository.findByAlias("testUser")).thenReturn(Optional.of(testProfile));
+
+		// 인터뷰 리스트 mocking
+		Optional<List<Interview>> mockedInterviewList = Optional.of(new ArrayList<>());
+		List<InterviewsResponseDto.InterviewSessionDto> mockedSessionDtos = new ArrayList<>();
+
+		long numOfInterviews = 10;
+		for (long i = 0; i < numOfInterviews; i++) {
+			mockedInterviewList.get().add(
+				Interview.builder()
+					.id(i)
+					.title("test title " + i)
+					.createdAt(LocalDateTime.of(2021, 10, 20, 10, 20))
+					.done(true)
+					.build()
+			);
+			mockedSessionDtos.add(InterviewsResponseDto.InterviewSessionDto.builder()
+				.sessionID(i)
+				.title("test title " + i)
+				.date("2021-10-20T10:20")
+				.score(0)
+				.done(true)
+				.build());
 		}
 
-		// findAllByProfileAlias()가 Optional<List<Interview>>를 반환하도록 설정
-		when(interviewRepository.findAllByProfileAlias(anyString())).thenReturn(Optional.of(mockInterviews));
+		when(interviewRepository.findAllByProfileId(testProfile.getId()))
+			.thenReturn(mockedInterviewList);
 
-		// Expected 인터뷰 세션 초기화
-		InterviewsResponseDto expectedResult = new InterviewsResponseDto();
-
-		expectedResult.setInterviewSessions(interviewSessionDtosList); // 빈 리스트로 초기화
+		InterviewsResponseDto mockedInterviewsResponseDto =
+			InterviewsResponseDto.builder().interviewSessions(mockedSessionDtos).build();
 
 		// When
-		InterviewsResponseDto interviewsResponseDto = interviewService.getInterviews();
+		InterviewsResponseDto actualInterviewsResponseDto =
+			interviewService.findAllInterviews();
 
-		// Then
-		Assertions.assertNotNull(interviewsResponseDto);
-
-		// List 초기화가 필요
-		List<InterviewsResponseDto.InterviewSessionDto> expectedSessions = expectedResult.getInterviewSessions();
-		List<InterviewsResponseDto.InterviewSessionDto> actualSessions = interviewsResponseDto.getInterviewSessions();
-
-		Assertions.assertNotNull(expectedSessions); // Null 체크 추가
-		Assertions.assertNotNull(actualSessions);   // Null 체크 추가
-
-		// 실제 세션과 기대하는 세션 비교
-		for (int i = 0; i < expectedSessions.size(); i++) {
-			InterviewsResponseDto.InterviewSessionDto expectedSession = expectedSessions.get(i);
-			InterviewsResponseDto.InterviewSessionDto actualSession = actualSessions.get(i);
-			System.out.println("Expected: SessionID: " + expectedSession.getSessionID() + ", Title: " + expectedSession.getTitle());
-			System.out.println("Actual: SessionID: " + actualSession.getSessionID() + ", Title: " + actualSession.getTitle());
-
-			// Assertions을 통해 값 비교
-			Assertions.assertEquals(expectedSession.getSessionID(), actualSession.getSessionID());
-			Assertions.assertEquals(expectedSession.getTitle(), actualSession.getTitle());
+		//Then
+		Assertions.assertNotNull(actualInterviewsResponseDto);
+		Assertions.assertEquals(actualInterviewsResponseDto.getInterviewSessions().size(), mockedInterviewList.get().size());
+		for (int i = 0; i < actualInterviewsResponseDto.getInterviewSessions().size(); i++) {
+			Assertions.assertEquals(actualInterviewsResponseDto.getInterviewSessions().get(i).getSessionID(), mockedSessionDtos.get(i).getSessionID());
+			Assertions.assertEquals(actualInterviewsResponseDto.getInterviewSessions().get(i).getTitle(), mockedSessionDtos.get(i).getTitle());
+			Assertions.assertEquals(actualInterviewsResponseDto.getInterviewSessions().get(i).getDate(), mockedSessionDtos.get(i).getDate());
+			Assertions.assertEquals(actualInterviewsResponseDto.getInterviewSessions().get(i).getScore(), mockedSessionDtos.get(i).getScore());
+			Assertions.assertEquals(actualInterviewsResponseDto.getInterviewSessions().get(i).getDone(), mockedSessionDtos.get(i).getDone());
 		}
 	}
 
@@ -191,102 +279,392 @@ public class InterviewServiceTest {
 		Assertions.assertEquals(totalNumOfQuestions, resultOfNumOfTotalQuestions);
 	}
 
+	/**
+	 * public InterviewQna findInterviewQnaById(Long qnaId) {
+	 * 		return interviewQnaRepository
+	 * 			.findById(qnaId)
+	 * 			.orElseThrow(InterviewException.QuestionNotFoundException::new);
+	 * 	    }
+	 */
+
+	/**
+	 * @Transactional
+	 * 	    public void updateInterviewQnaByAnswer (InterviewAnswerRequestDto interviewAnswerRequestDto) {
+	 * 		Long qnaId = interviewAnswerRequestDto.getQuestionIndex();
+	 * 		String requestedAnswer = interviewAnswerRequestDto.getAnswer();
+	 *
+	 * 		InterviewQna interviewQna = findInterviewQnaById(qnaId);
+	 *
+	 * 		interviewQna.setAnswer(requestedAnswer);
+	 * 		interviewQnaRepository.save(interviewQna);
+	 *    }
+	 *    여기서 저장이 잘 되는지 확인하기.
+	 */
 	@Test
-	@DisplayName("질문 생성 테스트")
-	void createInterviewQnaTest() {
+	@DisplayName("인터뷰 qna 테이블 업데이트 테스트")
+	void updateInterviewQnaByAnswerTest() {
 		// Given
-		Interview interview = new Interview(new Profile("test user"), "teset interveiw");
-		when(interviewRepository.save(any(Interview.class))).thenReturn(interview);
+		InterviewAnswerRequestDto mockedInterviewAnswerResponseDto =
+			InterviewAnswerRequestDto.builder()
+				.questionIndex(1L)
+				.answer("test answer")
+				.build();
 
-		Map<Long, Integer> categoryIdAndNumList = new HashMap<>();
-		categoryIdAndNumList.put(1L, 3);
-		categoryIdAndNumList.put(2L, 4);
-		categoryIdAndNumList.put(3L, 1);
-		categoryIdAndNumList.put(4L, 2);
+		InterviewQna mockedInterviewQna = InterviewQna.builder()
+			.id(1L)
+			.questionCategory(
+				QuestionCategory.builder()
+					.id(1L)
+					.question(Question.builder().id(1L).content("test question").build())
+					.category(Category.builder().id(1L).content("test category").build())
+					.build()
+			)
+			.answer(null)
+			.build();
 
-		List<QuestionCategory> mockQuestionCategories = new ArrayList<>();
-		for (Map.Entry<Long, Integer> entry : categoryIdAndNumList.entrySet()) {
-			Long categoryId = entry.getKey();
-			Integer numQuestions = entry.getValue();
+		InterviewQna expectedResult = InterviewQna.builder()
+			.id(1L)
+			.questionCategory(
+				QuestionCategory.builder()
+					.id(1L)
+					.question(Question.builder().id(1L).content("test question").build())
+					.category(Category.builder().id(1L).content("test category").build())
+					.build()
+			)
+			.answer("test answer")
+			.build();
 
-			// 각 카테고리에 대해 필요한 수만큼 질문 생성
-			for (int i = 1; i <= numQuestions; i++) {
-				Category category = new Category("Category " + categoryId); // 카테고리 생성
-				Question question = new Question("Question " + i + " for Category " + categoryId); // 질문 생성
-				QuestionCategory questionCategory = new QuestionCategory(question, category); // QuestionCategory 생성
-				mockQuestionCategories.add(questionCategory); // 리스트에 추가
-			}
-		}
-		when(questionCategoryRepository.findRandByCategoryIdList(categoryIdAndNumList))
-			.thenReturn(mockQuestionCategories);
+		when(interviewQnaRepository.findById(anyLong())).thenReturn(Optional.of(mockedInterviewQna));
 
 		// When
-		List<InterviewQna> interviewQnaList = interviewService.createInterviewQna(interview, categoryIdAndNumList);
+		InterviewQna actualInterviewQna = interviewService.updateInterviewQnaByAnswer(mockedInterviewAnswerResponseDto);
 
 		// Then
-		Assertions.assertNotNull(interviewQnaList);
-		Assertions.assertEquals(10, interviewQnaList.size());
-		for (InterviewQna interviewQna : interviewQnaList) {
-			Assertions.assertNotNull(interviewQna.getInterview());
-			Assertions.assertNotNull(interviewQna.getQuestionCategory());
+		Assertions.assertNotNull(actualInterviewQna);
+		Assertions.assertEquals(
+			actualInterviewQna.getQuestionCategory().getCategory().getContent(),
+			mockedInterviewQna.getQuestionCategory().getCategory().getContent());
+		Assertions.assertEquals(
+			actualInterviewQna.getQuestionCategory().getQuestion().getContent(),
+			mockedInterviewQna.getQuestionCategory().getQuestion().getContent());
+		Assertions.assertEquals(actualInterviewQna.getAnswer(), mockedInterviewAnswerResponseDto.getAnswer());
+	}
+
+	@Test
+	@DisplayName("인터뷰 카테고리 생성 테스트")
+	void createInterviewCategoriesTest() {
+		// Given
+		Long interviewId = 1L;
+		List<String> categoryNames = List.of("Category1", "Category2", "Category3");
+
+		// Mock Interview
+		Interview mockInterview = Interview.builder()
+			.id(interviewId)
+			.title("Test Interview")
+			.done(false)
+			.build();
+
+		// Mock Categories
+		Map<String, Category> mockCategories = new HashMap<>();
+		List<Long> expectedCategoryIds = new ArrayList<>();
+
+		for (int i = 0; i < categoryNames.size(); i++) {
+			Long categoryId = (long) (i + 1);
+			Category category = Category.builder()
+				.id(categoryId)
+				.content(categoryNames.get(i))
+				.build();
+			mockCategories.put(categoryNames.get(i), category);
+			expectedCategoryIds.add(categoryId);
+		}
+
+		// Mock Repository responses
+		when(interviewRepository.findById(interviewId)).thenReturn(Optional.of(mockInterview));
+		mockCategories.forEach((name, category) ->
+			when(categoryRepository.findByContent(name)).thenReturn(Optional.of(category)));
+
+		// When
+		List<Long> actualCategoryIds = interviewService.createInterviewCategories(interviewId, categoryNames);
+
+		// Then
+		Assertions.assertNotNull(actualCategoryIds);
+		Assertions.assertEquals(expectedCategoryIds.size(), actualCategoryIds.size());
+		for (int i = 0; i < expectedCategoryIds.size(); i++) {
+			Assertions.assertEquals(expectedCategoryIds.get(i), actualCategoryIds.get(i));
 		}
 	}
 
 	@Test
-	@DisplayName("답변 받기 테스트")
-	void getInterviewAnswerTest() {
+	@DisplayName("인터뷰 리포트 생성 테스트")
+	void createInterviewReportTest() {
 		// Given
-		InterviewAnswerRequestDto interviewAnswerRequestDto =
-			new InterviewAnswerRequestDto(3L, "test interview answer");
+		Long interviewId = 1L;
+		LocalDateTime createdAt = LocalDateTime.of(2024, 3, 28, 10, 0);
+		String interviewTitle = "Test Interview";
+		int numOfQuestions = 10;
 
-		long interviewId = 1L;
+		// Mock Authentication
+		Authentication authentication = mock(Authentication.class);
+		when(authentication.getName()).thenReturn("1"); // userId를 String으로 "1" 반환
 
-		// Expected
-		InterviewAnswerResponseDto expectedResult = new InterviewAnswerResponseDto(true);
-		when(interviewService.getInterviewAnswer(interviewAnswerRequestDto, interviewId))
-			.thenReturn(expectedResult);
+		SecurityContext securityContext = mock(SecurityContext.class);
+		when(securityContext.getAuthentication()).thenReturn(authentication);
+		SecurityContextHolder.setContext(securityContext);
+
+		// Mock Interview
+		Interview mockInterview = Interview.builder()
+			.id(interviewId)
+			.title(interviewTitle)
+			.createdAt(createdAt)
+			.done(true)
+			.build();
+
+		// Mock InterviewQna List
+		List<InterviewQna> mockInterviewQnas = new ArrayList<>();
+		for (int i = 0; i < numOfQuestions; i++) {
+			Question question = Question.builder()
+				.id((long) i)
+				.content("Test Question " + i)
+				.build();
+
+			Category category = Category.builder()
+				.id((long) i)
+				.content("Test Category " + i)
+				.build();
+
+			QuestionCategory questionCategory = QuestionCategory.builder()
+				.id((long) i)
+				.question(question)
+				.category(category)
+				.build();
+
+			InterviewQna qna = InterviewQna.builder()
+				.id((long) i)
+				.interview(mockInterview)
+				.questionCategory(questionCategory)
+				.answer("Test Answer " + i)
+				.build();
+
+			mockInterviewQnas.add(qna);
+		}
+
+		// Mock Repository responses
+		when(interviewRepository.findById(interviewId)).thenReturn(Optional.of(mockInterview));
+		when(interviewQnaRepository.findAllByInterviewId(interviewId)).thenReturn(mockInterviewQnas);
 
 		// When
-		InterviewAnswerResponseDto interviewAnswerResponseDto =
-			interviewService.getInterviewAnswer(interviewAnswerRequestDto, interviewId);
+		InterviewReportResponseDto reportDto = interviewService.createInterviewReport(interviewId);
 
 		// Then
-		Assertions.assertNotNull(interviewAnswerResponseDto);
-		Assertions.assertEquals(interviewAnswerResponseDto.getDone(), expectedResult.getDone());
+		Assertions.assertNotNull(reportDto);
+		Assertions.assertEquals(interviewId, reportDto.getSessionID());
+		Assertions.assertEquals(interviewTitle, reportDto.getTitle());
+		Assertions.assertEquals(createdAt.toString(), reportDto.getDate());
+
+		// QnA 검증
+		List<InterviewReportResponseDto.InterviewQnaReportDto> qnaReports = reportDto.getInterviewQNAs();
+		Assertions.assertEquals(numOfQuestions, qnaReports.size());
+
+		for (int i = 0; i < numOfQuestions; i++) {
+			InterviewReportResponseDto.InterviewQnaReportDto qnaReport = qnaReports.get(i);
+			Assertions.assertEquals("Test Question " + i, qnaReport.getQuestion());
+			Assertions.assertEquals("Test Answer " + i, qnaReport.getAnswer());
+		}
+	}
+
+	@Test
+	@DisplayName("인터뷰 질문 생성 테스트")
+	void createInterviewQuestionsTest() {
+		// Given
+		Long interviewId = 1L;
+		List<Long> categoryIds = List.of(1L, 2L, 3L);
+
+		// Mock Interview
+		Interview mockInterview = Interview.builder()
+			.id(interviewId)
+			.title("Test Interview")
+			.done(false)
+			.build();
+
+		// Mock Questions and Categories
+		List<QuestionCategory> mockQuestionCategories = new ArrayList<>();
+		for (int i = 0; i < 10; i++) { // 총 10개의 질문 생성
+			Question question = Question.builder()
+				.id((long) i)
+				.content("Test Question " + i)
+				.build();
+
+			Category category = Category.builder()
+				.id(categoryIds.get(i % categoryIds.size()))
+				.content("Test Category " + (i % categoryIds.size()))
+				.build();
+
+			QuestionCategory questionCategory = QuestionCategory.builder()
+				.id((long) i)
+				.question(question)
+				.category(category)
+				.build();
+
+			mockQuestionCategories.add(questionCategory);
+		}
+
+		// Mock Repository responses
+		when(interviewRepository.findById(interviewId)).thenReturn(Optional.of(mockInterview));
+		when(questionCategoryRepository.findRandByCategoryIdList(any())).thenReturn(mockQuestionCategories);
+
+		// Mock InterviewQna saves
+		List<InterviewQna> mockInterviewQnas = mockQuestionCategories.stream()
+			.map(qc -> InterviewQna.builder()
+				.interview(mockInterview)
+				.questionCategory(qc)
+				.build())
+			.collect(Collectors.toList());
+		when(interviewQnaRepository.saveAll(any())).thenReturn(mockInterviewQnas);
+
+		// When
+		interviewService.createInterviewQuestions(interviewId, categoryIds);
+
+		// Then
+		// 1. Interview가 존재하는지 확인
+		verify(interviewRepository).findById(interviewId);
+
+		// 2. 질문이 분배되었는지 확인
+		verify(questionCategoryRepository).findRandByCategoryIdList(any());
+
+		// 3. InterviewQna가 저장되었는지 확인
+		verify(interviewQnaRepository).saveAll(any());
+	}
+
+	@Test
+	@DisplayName("답변 받기 테스트")
+	void updateInterviewAnswerTest() {
+		// Given
+		InterviewAnswerRequestDto mockedInterviewAnswerResponseDto =
+			InterviewAnswerRequestDto.builder()
+				.questionIndex(1L)
+				.answer("test answer")
+				.build();
+
+		when(interviewQnaRepository.findById(anyLong())).thenReturn(
+			Optional.ofNullable(InterviewQna.builder()
+				.id(1L)
+				.questionCategory(
+					QuestionCategory.builder()
+						.id(1L)
+						.question(Question.builder().id(1L).content("test question").build())
+						.category(Category.builder().id(1L).content("test category").build())
+						.build()
+				)
+				.answer(null)
+				.build())
+		);
+
+		// Expected
+		InterviewQna expectedResult = InterviewQna.builder()
+			.id(1L)
+			.questionCategory(
+				QuestionCategory.builder()
+					.id(1L)
+					.question(Question.builder().id(1L).content("test question").build())
+					.category(Category.builder().id(1L).content("test category").build())
+					.build()
+			)
+			.answer("test answer")
+			.build();
+
+		// When
+		InterviewQna actualResult = interviewService.updateInterviewQnaByAnswer(mockedInterviewAnswerResponseDto);
+
+		// Then
+		Assertions.assertNotNull(actualResult);
+	}
+
+	@Test
+	@DisplayName("모두 답변 완료 체크")
+	void isAllAnsweredTest() {
+		// Given
+		List<InterviewQna> interviewQnaList = new ArrayList<>();
+		int numOfQnas = 10;
+		for (int i = 0; i < numOfQnas; i++) {
+			interviewQnaList.add(InterviewQna.builder()
+				.interview(Interview.builder()
+					.id(1L)
+					.title("test title")
+					.build())
+				.questionCategory(QuestionCategory.builder()
+					.id(1L)
+					.question(Question.builder().id(1L).content("test question" + i).build())
+					.category(Category.builder().id(1L).content("test category" + i).build())
+					.build())
+				.answer("test answer" + i)
+				.build());
+		}
+
+		// When
+		when(interviewQnaRepository.findAllByInterviewId(anyLong())).thenReturn(interviewQnaList);
+		boolean actualResult = interviewService.isAllAnswered(1L);
+
+		// Then
+		Assertions.assertTrue(actualResult, "모든 질문에 답변이 있을 경우 true를 반환해야 합니다");
 	}
 
 	@Test
 	@DisplayName("면접 문답 모두 가져오기")
 	void findAllInterviewQnasTest() {
 		// Given
-		long interviewId = 1L;
+		Long interviewId = 1L;
+		int numOfQuestions = 10;
 
-		List<InterviewQuestionResponseDto.QuestionDto> questionDtoList = new ArrayList<>();
-		for (int i = 0; i < 5; i++) {
-			InterviewQuestionResponseDto.QuestionDto questionDto =
-				new InterviewQuestionResponseDto.QuestionDto(
-					"test question " + i, 1L + i, "test answer " + i);
-			questionDtoList.add(questionDto);
+		// Mock InterviewQna List 생성
+		List<InterviewQna> mockInterviewQnas = new ArrayList<>();
+		for (int i = 0; i < numOfQuestions; i++) {
+			Question question = Question.builder()
+				.id((long) i)
+				.content("Test Question " + i)
+				.build();
+
+			Category category = Category.builder()
+				.id((long) i)
+				.content("Test Category " + i)
+				.build();
+
+			QuestionCategory questionCategory = QuestionCategory.builder()
+				.id((long) i)
+				.question(question)
+				.category(category)
+				.build();
+
+			InterviewQna qna = InterviewQna.builder()
+				.id((long) i)
+				.interview(Interview.builder()
+					.id(interviewId)
+					.title("Test Interview")
+					.build())
+				.questionCategory(questionCategory)
+				.answer("Test Answer " + i)
+				.build();
+
+			mockInterviewQnas.add(qna);
 		}
 
-		InterviewQuestionResponseDto expectedResult = new InterviewQuestionResponseDto(questionDtoList);
-		when(interviewService.findAllInterviewQnas(interviewId)).thenReturn(expectedResult);
+		// Mock Repository Response
+		when(interviewQnaRepository.findAllByInterviewId(interviewId)).thenReturn(mockInterviewQnas);
 
 		// When
-		InterviewQuestionResponseDto actualResult = interviewService.findAllInterviewQnas(interviewId);
-
+		InterviewQuestionResponseDto responseDto = interviewService.findAllInterviewQnas(interviewId);
 
 		// Then
-		Assertions.assertNotNull(actualResult);
-		Assertions.assertEquals(expectedResult.getQuestions().size(), actualResult.getQuestions().size());
+		Assertions.assertNotNull(responseDto, "응답 DTO가 null이 아니어야 합니다");
+		Assertions.assertNotNull(responseDto.getQuestions(), "질문 리스트가 null이 아니어야 합니다");
+		Assertions.assertEquals(numOfQuestions, responseDto.getQuestions().size(), "질문 수가 일치해야 합니다");
 
-		for (int i = 0; i < expectedResult.getQuestions().size(); i++) {
-			InterviewQuestionResponseDto.QuestionDto expectedDto = expectedResult.getQuestions().get(i);
-			InterviewQuestionResponseDto.QuestionDto actualDto = actualResult.getQuestions().get(i);
-
-			Assertions.assertEquals(expectedDto.getQuestion(), actualDto.getQuestion());
-			Assertions.assertEquals(expectedDto.getQuestionIndex(), actualDto.getQuestionIndex());
-			Assertions.assertEquals(expectedDto.getAnswer(), actualDto.getAnswer());
+		// 각 질문의 세부 내용 검증
+		List<InterviewQuestionResponseDto.QuestionDto> questions = responseDto.getQuestions();
+		for (int i = 0; i < numOfQuestions; i++) {
+			InterviewQuestionResponseDto.QuestionDto questionDto = questions.get(i);
+			Assertions.assertEquals((long) i, questionDto.getQuestionIndex(), "질문 인덱스가 일치해야 합니다");
+			Assertions.assertEquals("Test Question " + i, questionDto.getQuestion(), "질문 내용이 일치해야 합니다");
+			Assertions.assertEquals("Test Answer " + i, questionDto.getAnswer(), "답변 내용이 일치해야 합니다");
 		}
 	}
 }


### PR DESCRIPTION
## 연관된 작업사항

## 작업내용
### 1. 보안 컨텍스트 관련 공통 로직 분리
- `getUserIdFromSecurityContext()` 메서드 추출
  - 사용자 인증 정보 조회 로직 분리
  - 예외 처리 개선
- `getProfileByUserId()` 메서드 추출
  - 프로필 조회 로직 분리
  - 재사용성 향상

### 2. 인터뷰 생성 로직 개선
- Builder 패턴 적용
  ```java
  Interview interview = Interview.builder()
      .profile(profile)
      .title(interviewTitle)
      .done(false)
      .build();
  ```
- 단일 책임 원칙(SRP) 준수를 위한 기능 분리
  - 기본 인터뷰 정보 생성으로 역할 한정
  - 카테고리 및 질문 생성 로직을 별도 메서드로 분리

## Reference
- [Clean Code] 단일 책임 원칙(SRP)
- [Design Pattern] Builder Pattern
- [Spring Security] SecurityContextHolder

## etc.
- 후속 작업으로 카테고리 생성 로직 리팩토링 필요
- 인터뷰 생성 프로세스 관련 로깅 추가 고려
